### PR TITLE
PR 2 - Cleanup preview on unmount

### DIFF
--- a/app/(auth)/music/index.tsx
+++ b/app/(auth)/music/index.tsx
@@ -26,7 +26,7 @@ const Albums = () => {
   const [isSpotifySearched, setIsSpotifySearched] = useState(false);
   const [searchedUpMusic, setSearchedUpMusic] = useState<Music[]>([]);
   const [searchText, setSearchText] = useState(" ");
-  const [isLoading, setisLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
   const [buttonColor, setButtonColor] = useState({slot1: '',slot2: ''});
   const [isRefreshing, setIsRefreshing] = useState(false);
 
@@ -49,24 +49,24 @@ const Albums = () => {
       else{
       const musicData = await getMusic();
       setMusic(musicData);
-      setisLoading(false);}
+      setIsLoading(false);}
     })();
   }, [params]);
 
   const handleSearchSubmit = async (artistName: string) => {
-    setisLoading(true);
+    setIsLoading(true);
       try {
         const spotifyMusic = await getSpotifyMusic('album', artistName);
         setSearchText(artistName)
         setDropDVis(false);
-        setisLoading(false);
+        setIsLoading(false);
         setIsSpotifySearched(true);
         setSearchedUpMusic(spotifyMusic);
       } catch (err) {
         router.setParams({})
         console.log("🚀 ~ handleSearchSubmit ~ err:", err);
       } finally {
-        setisLoading(false);
+        setIsLoading(false);
         
       }
     

--- a/app/(auth)/music/index.tsx
+++ b/app/(auth)/music/index.tsx
@@ -152,7 +152,7 @@ const Albums = () => {
             <RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />
           }
         >
-          <View className="flex flex-row flex-wrap justify-between bg-pink-50 mb-20 mt-5 h-[85%]">
+          <View className="flex flex-row flex-wrap justify-between bg-pink-50 mb-20 mt-2 h-[85%]">
             {searchedUpMusic.map((track) => (
               <Pressable
                 key={track.music_id}
@@ -182,7 +182,7 @@ const Albums = () => {
             <RefreshControl refreshing={isRefreshing} onRefresh={onRefresh} />
           }
         >
-          <View className="flex flex-row flex-wrap justify-between bg-white min-h-fit">
+          <View className="flex flex-row flex-wrap justify-between bg-white min-h-fit pt-2">
             {music.map((track) => (
               <Pressable
                 key={track.music_id}

--- a/app/(auth)/users/[username]/index.tsx
+++ b/app/(auth)/users/[username]/index.tsx
@@ -1,15 +1,29 @@
-import { Pressable, Text, View } from "react-native";
+import { Pressable, Text, View, ScrollView } from "react-native";
 import { useContext, useEffect, useState } from "react";
-import { useGlobalSearchParams } from "expo-router";
-import { getFollows, patchFollows } from "../../../../utils/api";
+import { router, useGlobalSearchParams } from "expo-router";
+import {
+  getFollows,
+  getReviewsByUsername,
+  patchFollows,
+} from "../../../../utils/api";
 import UserItem from "../../../../components/UserItem";
 import { UserContext } from "../../../../contexts/UserContent";
+import ReviewHistory from "../../../../components/ReviewHistory";
 
 const UserPage = () => {
   const { user, setUser } = useContext(UserContext);
   const { username } = useGlobalSearchParams();
   const [connections, setConnections] = useState([]);
-    /* const [activity, setActivity] = useState([])*/
+  const [activity, setActivity] = useState([]);
+
+  useEffect(() => {
+    !username && router.push(`/(auth)/`);
+
+    (async () => {
+      const userReviews = await getReviewsByUsername(username as string);
+      setActivity(userReviews);
+    })();
+  }, []);
 
   const handleFollow = () => {
     setUser(({ ...current }) => {
@@ -32,7 +46,6 @@ const UserPage = () => {
   };
 
   useEffect(() => {
-    /*request and set the activity based on username here?*/
     (async () => {
       try {
         const { following } = await getFollows(username as string);
@@ -46,50 +59,25 @@ const UserPage = () => {
   return (
     <View>
       <Text className="p-4 my-auto font-bold text-lg">
-        {username}'s activity
+        {username}'s activity:
       </Text>
-      {/* this is where we want the feed of 
-      recent reviews for a user to go maybe 3 most recent reviews?
 
-      once in styling will need messing with, 
-      could have writing on the right of the album instead of underneath
-      display in a column rather than a grid.
+      <ReviewHistory activity={activity} />
 
-          {activity.map((track)=>(
-            <Pressable
-                key={track.music_id}
-                onPress={() => router.push(`/(auth)/music/${track.music_id}`)}
-                className="w-1/2 h-auto"
-              >
-                <View
-                  key={track.music_id}
-                  className=" p-4 bg-white rounded-lg items-center justify-center"
-                >
-                  <Image
-                    source={{ uri: track.album_img }}
-                    className="w-40 h-40  rounded-lg"
-                  />
-                  <Text className="text-center py-1">{track.artist_names}</Text>
-                  <Text className="text-center">{track.name}</Text>
-                </View>
-              </Pressable>)
-        )}
-      
-      */}
       {user.following.includes(username as string) ? (
         <Pressable onPress={handleUnfollow}>
-          <Text className="p-4">{username} is Following</Text>
+          <Text className="p-4 font-bold text-lg">{username} is Following</Text>
         </Pressable>
       ) : (
         <Pressable onPress={handleFollow}>
-          <Text>Follow</Text>
+          <Text className="p-4 font-bold text-lg">Follow</Text>
         </Pressable>
       )}
-      <View className="px-4">
+      <ScrollView className="px-4 mb-4 h-[33vh] mx-4 bg-white rounded-lg">
         {connections.map((user) => (
           <UserItem key={user} username={user} textModifier="text-lg" />
         ))}
-      </View>
+      </ScrollView>
     </View>
   );
 };

--- a/app/(auth)/users/[username]/index.tsx
+++ b/app/(auth)/users/[username]/index.tsx
@@ -1,4 +1,4 @@
-import { Pressable, Text, View, ScrollView } from "react-native";
+import { Pressable, Text, View, ScrollView, ActivityIndicator } from "react-native";
 import { useContext, useEffect, useState } from "react";
 import { router, useGlobalSearchParams } from "expo-router";
 import {
@@ -13,17 +13,9 @@ import ReviewHistory from "../../../../components/ReviewHistory";
 const UserPage = () => {
   const { user, setUser } = useContext(UserContext);
   const { username } = useGlobalSearchParams();
+  const [loading, setLoading] = useState(true);
   const [connections, setConnections] = useState([]);
   const [activity, setActivity] = useState([]);
-
-  useEffect(() => {
-    !username && router.push(`/(auth)/`);
-
-    (async () => {
-      const userReviews = await getReviewsByUsername(username as string);
-      setActivity(userReviews);
-    })();
-  }, []);
 
   const handleFollow = () => {
     setUser(({ ...current }) => {
@@ -46,17 +38,29 @@ const UserPage = () => {
   };
 
   useEffect(() => {
+    !username && router.push(`/(auth)/`);
+
     (async () => {
       try {
         const { following } = await getFollows(username as string);
+        const userReviews = await getReviewsByUsername(username as string);
         setConnections(following);
+        setActivity(userReviews);
+        setLoading(false);
       } catch (error) {
         console.log("🚀 ~ error:", error);
       }
     })();
   }, [username, user]);
 
-  return (
+  return loading ? (
+    <ActivityIndicator
+      size="large"
+      style={{ transform: [{ scaleX: 2 }, { scaleY: 2 }] }}
+      color="#B56DE4"
+      className="m-auto"
+    />
+  ) : (
     <View>
       <Text className="p-4 my-auto font-bold text-lg">
         {username}'s activity:

--- a/app/(auth)/users/index.tsx
+++ b/app/(auth)/users/index.tsx
@@ -1,14 +1,16 @@
-import { useContext, useEffect } from "react";
-import { Pressable, Text, View } from "react-native";
+import { useContext, useEffect, useState } from "react";
+import { Pressable, ScrollView, Text, View } from "react-native";
 import UserItem from "../../../components/UserItem";
 import { UserContext } from "../../../contexts/UserContent";
 import { supabase } from "../../../lib/supabase";
 import { router } from "expo-router";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { getReviewsByUsername } from "../../../utils/api";
+import ReviewHistory from "../../../components/ReviewHistory";
 
 const CurrentUser = () => {
   const { user, setUser } = useContext(UserContext);
-  /* const [activity, setActivity] = useState([])*/
+  const [activity, setActivity] = useState([]);
 
   const handleSignOut = async () => {
     await supabase.auth.signOut();
@@ -18,7 +20,12 @@ const CurrentUser = () => {
   };
 
   useEffect(() => {
-    /* make the request for activity and set state here?*/
+    user.username &&
+      (async () => {
+        const userReviews = await getReviewsByUsername(user.username);
+        setActivity(userReviews);
+      })();
+
     !user.username && router.push(`/(auth)/`);
   }, []);
 
@@ -36,44 +43,18 @@ const CurrentUser = () => {
         </Pressable>
       </View>
       <View>
-        <Text className="p-4 my-auto font-bold text-lg">Recent Activity</Text>
-        {/* this is where we want the recent 
-        reviewed music to go... last 3 reviews?
-        seperate get request per the user.username and add that to a new piece of state?
-          
-        once in styling will need messing with, 
-        could have writing on the right of the album instead of underneath
-        display in a column rather than a grid.
-        
-        {activity.map((track)=>(
-            <Pressable
-                key={track.music_id}
-                onPress={() => router.push(`/(auth)/music/${track.music_id}`)}
-                className="w-1/2 h-auto"
-              >
-                <View
-                  key={track.music_id}
-                  className=" p-4 bg-white rounded-lg items-center justify-center"
-                >
-                  <Image
-                    source={{ uri: track.album_img }}
-                    className="w-40 h-40  rounded-lg"
-                  />
-                  <Text className="text-center py-1">{track.artist_names}</Text>
-                  <Text className="text-center">{track.name}</Text>
-                </View>
-              </Pressable>)
-        )}
-        
-        */}
+        <Text className="px-4 pb-4 my-auto font-bold text-lg">
+          Recent Activity:
+        </Text>
+        <ReviewHistory activity={activity} />
       </View>
-      <Text className="p-4">You are folowing :</Text>
-
-      <View className="px-4">
-        {user.following.map((user) => (
-          <UserItem key={user} username={user} textModifier="text-lg" />
-        ))}
-      </View>
+      <Text className="p-4 font-bold text-lg">You are following:</Text>
+      <ScrollView className="px-4 mb-4 h-[33vh] mx-4 bg-white rounded-lg">
+        {user.following.length &&
+          user.following.map((user) => (
+            <UserItem key={user} username={user} textModifier="text-lg" />
+          ))}
+      </ScrollView>
     </View>
   );
 };

--- a/app/(auth)/users/index.tsx
+++ b/app/(auth)/users/index.tsx
@@ -1,5 +1,11 @@
 import { useContext, useEffect, useState } from "react";
-import { Pressable, ScrollView, Text, View } from "react-native";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
 import UserItem from "../../../components/UserItem";
 import { UserContext } from "../../../contexts/UserContent";
 import { supabase } from "../../../lib/supabase";
@@ -9,6 +15,7 @@ import { getReviewsByUsername } from "../../../utils/api";
 import ReviewHistory from "../../../components/ReviewHistory";
 
 const CurrentUser = () => {
+  const [loading, setLoading] = useState(true);
   const { user, setUser } = useContext(UserContext);
   const [activity, setActivity] = useState([]);
 
@@ -25,10 +32,18 @@ const CurrentUser = () => {
     (async () => {
       const userReviews = await getReviewsByUsername(user.username);
       setActivity(userReviews);
+      setLoading(false);
     })();
   }, []);
 
-  return (
+  return loading ? (
+    <ActivityIndicator
+      size="large"
+      style={{ transform: [{ scaleX: 2 }, { scaleY: 2 }] }}
+      color="#B56DE4"
+      className="m-auto"
+    />
+  ) : (
     <View>
       <View className="flex flex-row justify-between">
         <Text className="p-4 my-auto font-bold text-lg">
@@ -49,10 +64,9 @@ const CurrentUser = () => {
       </View>
       <Text className="p-4 font-bold text-lg">You are following:</Text>
       <ScrollView className="px-4 mb-4 h-[33vh] mx-4 bg-white rounded-lg">
-        {user.following.length &&
-          user.following.map((user) => (
-            <UserItem key={user} username={user} textModifier="text-lg" />
-          ))}
+        {user.following.map((user) => (
+          <UserItem key={user} username={user} textModifier="text-lg" />
+        ))}
       </ScrollView>
     </View>
   );

--- a/app/(auth)/users/index.tsx
+++ b/app/(auth)/users/index.tsx
@@ -20,13 +20,12 @@ const CurrentUser = () => {
   };
 
   useEffect(() => {
-    user.username &&
-      (async () => {
-        const userReviews = await getReviewsByUsername(user.username);
-        setActivity(userReviews);
-      })();
-
     !user.username && router.push(`/(auth)/`);
+
+    (async () => {
+      const userReviews = await getReviewsByUsername(user.username);
+      setActivity(userReviews);
+    })();
   }, []);
 
   return (

--- a/app/(auth)/users/index.tsx
+++ b/app/(auth)/users/index.tsx
@@ -30,9 +30,13 @@ const CurrentUser = () => {
     !user.username && router.push(`/(auth)/`);
 
     (async () => {
-      const userReviews = await getReviewsByUsername(user.username);
-      setActivity(userReviews);
-      setLoading(false);
+      try {
+        const userReviews = await getReviewsByUsername(user.username);
+        setActivity(userReviews);
+        setLoading(false);
+      } catch (error) {
+        console.log("🔎 ~ file: index.tsx:39 ~ error:", error);
+      }
     })();
   }, []);
 

--- a/components/AlbumPage.tsx
+++ b/components/AlbumPage.tsx
@@ -41,7 +41,6 @@ const AlbumPage = () => {
 
   useEffect((): any => {
     return async () => {
-      console.log("unloading media");
       await playableMedia?.unloadAsync();
     };
   }, [playableMedia]);

--- a/components/AlbumPage.tsx
+++ b/components/AlbumPage.tsx
@@ -1,6 +1,6 @@
 import { Text, View, Image, Pressable } from "react-native";
 import { Music, Track } from "../types/front-end";
-import React, { useEffect, useState } from "react";
+import React, { EffectCallback, useEffect, useState } from "react";
 import { useGlobalSearchParams } from "expo-router";
 import { getMusic, getSpotifyTrackList } from "../utils/api";
 import { Audio } from "expo-av";
@@ -13,7 +13,7 @@ const AlbumPage = () => {
   const [musicContent, setMusicContent] = useState<Music>();
   const [ratingColor, setRatingColor] = useState("text-green-800");
   const [isPlaying, setIsPlaying] = useState(false);
-  const [sound, setSound] = useState<Audio.Sound | undefined>();
+  const [playableMedia, setPlayableMedia] = useState<Audio.Sound | undefined>();
   const [isAlbumFlipped, setIsAlbumFlipped] = useState(false);
   const [tracks, setTracks] = useState<Track[] | []>([]);
 
@@ -39,6 +39,13 @@ const AlbumPage = () => {
     })();
   }, []);
 
+  useEffect((): any => {
+    return async () => {
+      console.log("unloading media");
+      await playableMedia?.unloadAsync();
+    };
+  }, [playableMedia]);
+
   const handlePlay = async () => {
     await playPreview(!isPlaying);
   };
@@ -51,11 +58,15 @@ const AlbumPage = () => {
         },
         { shouldPlay: true }
       );
-      setSound(sound);
+      setPlayableMedia(sound);
 
-      await sound.playAsync();
-    } else if (typeof musicContent?.preview === "string" && !bool && sound) {
-      await sound.unloadAsync();
+      playableMedia && (await playableMedia.playAsync());
+    } else if (
+      typeof musicContent?.preview === "string" &&
+      !bool &&
+      playableMedia
+    ) {
+      await playableMedia.unloadAsync();
     }
     setIsPlaying((current) => {
       return !current;

--- a/components/ReviewHistory.tsx
+++ b/components/ReviewHistory.tsx
@@ -2,7 +2,6 @@ import { router } from "expo-router";
 import { Pressable, View, Image, Text, ScrollView } from "react-native";
 
 const ReviewHistory = ({ activity }: { activity: any }) => {
-  console.log(activity);
   return (
     <ScrollView className="max-h-[35vh] mx-4 bg-white rounded-lg">
       {activity.map(

--- a/components/ReviewHistory.tsx
+++ b/components/ReviewHistory.tsx
@@ -1,5 +1,6 @@
 import { router } from "expo-router";
 import { Pressable, View, Image, Text, ScrollView } from "react-native";
+import RatingWheel from "./reusable-components/RatingWheel";
 
 const ReviewHistory = ({ activity }: { activity: any }) => {
   return (
@@ -13,6 +14,7 @@ const ReviewHistory = ({ activity }: { activity: any }) => {
           artist_names: string[];
           name: string;
           created_at: string;
+          rating: number;
         }) => (
           <Pressable
             key={trackReview.music_id}
@@ -21,13 +23,20 @@ const ReviewHistory = ({ activity }: { activity: any }) => {
           >
             <View
               key={trackReview.review_id}
-              className="h-max p-4 flex flex-row justify-between"
+              className="h-max p-4 flex flex-row justify-between border-violet-800 border-b"
             >
-              <Image
-                source={{ uri: trackReview.album_img }}
-                className="h-28 w-28  rounded-md"
-              />
-              <View className="w-[60%]">
+              <View>
+                <Image
+                  source={{ uri: trackReview.album_img }}
+                  className="h-24 w-24  rounded-md"
+                />
+
+                <View className="mx-auto mt-4">
+                  <RatingWheel rating={trackReview.rating} />
+                </View>
+              </View>
+
+              <View className="w-[66%]">
                 <Text className="text-sm font-bold text-center">
                   {trackReview.name}
                 </Text>
@@ -38,7 +47,7 @@ const ReviewHistory = ({ activity }: { activity: any }) => {
                   {trackReview.review_body}
                 </Text>
                 <Text className="text-xs text-slate-500 text-center">
-                  Posted On: {trackReview.created_at?.substring(0, 10)}
+                  Reviewed: {trackReview.created_at?.substring(0, 10)}
                 </Text>
               </View>
             </View>

--- a/components/ReviewHistory.tsx
+++ b/components/ReviewHistory.tsx
@@ -2,6 +2,7 @@ import { router } from "expo-router";
 import { Pressable, View, Image, Text, ScrollView } from "react-native";
 
 const ReviewHistory = ({ activity }: { activity: any }) => {
+  console.log(activity);
   return (
     <ScrollView className="max-h-[35vh] mx-4 bg-white rounded-lg">
       {activity.map(
@@ -12,6 +13,7 @@ const ReviewHistory = ({ activity }: { activity: any }) => {
           album_img: string;
           artist_names: string[];
           name: string;
+          created_at: string;
         }) => (
           <Pressable
             key={trackReview.music_id}
@@ -24,17 +26,20 @@ const ReviewHistory = ({ activity }: { activity: any }) => {
             >
               <Image
                 source={{ uri: trackReview.album_img }}
-                className="h-24 w-24  rounded-md"
+                className="h-28 w-28  rounded-md"
               />
               <View className="w-[60%]">
                 <Text className="text-sm font-bold text-center">
                   {trackReview.name}
                 </Text>
-                <Text className="text-xs font-bold text-center">
+                <Text className="text-xs font-bold text-center m-1">
                   {trackReview.artist_names[0]}
                 </Text>
-                <Text className="text-sm text-center my-2">
+                <Text className="text-md text-center my-1">
                   {trackReview.review_body}
+                </Text>
+                <Text className="text-xs text-slate-500 text-center">
+                  Posted On: {trackReview.created_at?.substring(0, 10)}
                 </Text>
               </View>
             </View>

--- a/components/ReviewHistory.tsx
+++ b/components/ReviewHistory.tsx
@@ -1,0 +1,48 @@
+import { router } from "expo-router";
+import { Pressable, View, Image, Text, ScrollView } from "react-native";
+
+const ReviewHistory = ({ activity }: { activity: any }) => {
+  return (
+    <ScrollView className="max-h-[35vh] mx-4 bg-white rounded-lg">
+      {activity.map(
+        (trackReview: {
+          music_id: string;
+          review_id: string;
+          review_body: string;
+          album_img: string;
+          artist_names: string[];
+          name: string;
+        }) => (
+          <Pressable
+            key={trackReview.music_id}
+            onPress={() => router.push(`/(auth)/music/${trackReview.music_id}`)}
+            className="mx-auto w-[90vw]"
+          >
+            <View
+              key={trackReview.review_id}
+              className="h-max p-4 flex flex-row justify-between"
+            >
+              <Image
+                source={{ uri: trackReview.album_img }}
+                className="h-24 w-24  rounded-md"
+              />
+              <View className="w-[60%]">
+                <Text className="text-sm font-bold text-center">
+                  {trackReview.name}
+                </Text>
+                <Text className="text-xs font-bold text-center">
+                  {trackReview.artist_names[0]}
+                </Text>
+                <Text className="text-sm text-center my-2">
+                  {trackReview.review_body}
+                </Text>
+              </View>
+            </View>
+          </Pressable>
+        )
+      )}
+    </ScrollView>
+  );
+};
+
+export default ReviewHistory;

--- a/components/reusable-components/RatingWheel.tsx
+++ b/components/reusable-components/RatingWheel.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import AnimatedProgressWheel from "react-native-progress-wheel";
+
+const RatingWheel = ({ rating }: { rating: number }) => {
+  const [ratingColor, setRatingColor] = useState("#9ce37d");
+
+  useEffect(() => {
+    if (rating < 7 && rating > 4) {
+      setRatingColor("#ffc145");
+    } else if (rating <= 4) {
+      setRatingColor("#ff6b6c");
+    }
+  }, []);
+
+  return (
+    <AnimatedProgressWheel
+      size={45}
+      width={7}
+      color={ratingColor}
+      progress={rating}
+      max={10}
+      showProgressLabel={true}
+      rotation={"-90deg"}
+      duration={750}
+      labelStyle={{
+        color: "black",
+        fontSize: 15,
+        fontWeight: "bold",
+      }}
+      backgroundColor={"#b56de4"}
+    />
+  );
+};
+
+export default RatingWheel;

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-native": "0.72.10",
         "react-native-elements": "^3.4.3",
         "react-native-gesture-handler": "~2.12.0",
+        "react-native-progress-wheel": "^2.1.0",
         "react-native-safe-area-context": "4.6.3",
         "react-native-screens": "~3.22.0",
         "react-native-url-polyfill": "^2.0.0",
@@ -16616,6 +16617,11 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/react-native-progress-wheel": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-progress-wheel/-/react-native-progress-wheel-2.1.0.tgz",
+      "integrity": "sha512-HXuPKwRNszvFMFlpoVWbn5tdxwkEowJGBNfydU8GGIEJcaZCT4Znraho+cfXbbW/fp9crVXoB8oV+zJr8sTAQQ=="
     },
     "node_modules/react-native-ratings": {
       "version": "8.0.4",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "expo-splash-screen": "~0.20.5",
     "expo-status-bar": "~1.6.0",
     "expo-system-ui": "~2.4.0",
+    "expo-updates": "~0.18.19",
     "expo-web-browser": "~12.3.2",
     "nativewind": "^2.0.11",
     "react": "18.2.0",
@@ -34,11 +35,11 @@
     "react-native": "0.72.10",
     "react-native-elements": "^3.4.3",
     "react-native-gesture-handler": "~2.12.0",
+    "react-native-progress-wheel": "^2.1.0",
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.22.0",
     "react-native-url-polyfill": "^2.0.0",
-    "react-native-web": "~0.19.6",
-    "expo-updates": "~0.18.19"
+    "react-native-web": "~0.19.6"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -53,7 +53,7 @@ export const getReviewsByUsername = async (username?: string) => {
 
     return response.data.reviews;
   } catch (err) {
-    console.log("🚀 ~ file: api.ts:24 ~ getReviews ~ err:", err);
+    console.log("🚀 ~ file: api.ts:24 ~ getReviewsByUsername ~ err:", err);
   }
 };
 


### PR DESCRIPTION
fix issue with preview still playing when album page unmounted. This resulted in a new instance of the playable music overlapping if you tried to start a new preview while it is still playing. Also caused any other media from other apps not playing until the Wax app was closed